### PR TITLE
Fixed-the-deleting-comment-bug

### DIFF
--- a/albumy/blueprints/main.py
+++ b/albumy/blueprints/main.py
@@ -362,6 +362,7 @@ def delete_comment(comment_id):
             and not current_user.can('MODERATE'):
         abort(403)
     db.session.delete(comment)
+    db.session.commit()
     flash('Comment deleted.', 'info')
     return redirect(url_for('.show_photo', photo_id=comment.photo_id))
 


### PR DESCRIPTION
Added the line db.session.commit() to the delete comment function in /albumy/blueprints/main.py to resolve the bug where the comment was being deleted but it was still appearing on the front end.

resolves #1 